### PR TITLE
heroku fix

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start 

--- a/package.json
+++ b/package.json
@@ -7,16 +7,16 @@
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "ethers": "^5.7.2",
+    "http-server": "^14.1.1",
     "protobufjs": "^7.5.1",
     "web3": "^1.7.4"
   },
   "scripts": {
-    "start": "http-server . -p 8080 --cors -P http://localhost:8080?",
+    "start": "http-server frontend -p $PORT --cors",
     "dev": "http-server frontend -p 8000 --cors -o",
     "compile-proto": "pbjs -t static-module -w commonjs -o frontend/proto/layer_proto.js frontend/proto/bridge/tx.proto && pbts -o frontend/proto/layer_proto.d.ts frontend/proto/layer_proto.js"
   },
   "devDependencies": {
-    "http-server": "^14.1.1",
     "protobufjs-cli": "^1.1.3"
   }
 }


### PR DESCRIPTION
Moved http-server to dependencies - Now Heroku can find it
Updated start script - Now uses $PORT and serves the frontend directory
Added Procfile - Explicitly tells Heroku to run npm start