### PR TITLE
blank fix

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,12 +6,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tellor Hub</title>
     <link rel="stylesheet" href="main.css" />
-    <link rel="stylesheet" href="space-station.css?v=24" />
+    <link rel="stylesheet" href="space-station.css?v=25" />
     <link rel="icon" type="image/x-icon" href="/drkgrnswsh.png">
-    <!-- Bridge gate: works even if space-station.css is stale; JS also re-applies from App.bridgeModuleUnderConstruction -->
+    <!-- Bridge gate: data attr alone must show overlay (space-station hides overlay unless .under-construction is on parent) -->
     <style>
       #bridgeSection[data-bridge-under-construction="1"] .bridge-real-content {
         display: none !important;
+      }
+      #bridgeSection[data-bridge-under-construction="1"] .under-construction-overlay {
+        display: flex !important;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        padding: 60px 24px;
+        gap: 12px;
+      }
+      .function-container > #bridgeSection.function-section.active[data-bridge-under-construction="1"] {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+      }
+      #bridgeSection.function-section.active[data-bridge-under-construction="1"] .under-construction-overlay {
+        flex: 1;
+        width: 100%;
+        box-sizing: border-box;
+        min-height: min(520px, 72vh);
       }
     </style>
 

--- a/frontend/space-station.css
+++ b/frontend/space-station.css
@@ -2231,19 +2231,22 @@ body:has(.function-focus-state) .frontend-code-link {
 }
 
 /* ── Under Construction Mode (bridge module) ── */
-.function-section.under-construction .bridge-real-content {
+.function-section.under-construction .bridge-real-content,
+#bridgeSection[data-bridge-under-construction="1"] .bridge-real-content {
   display: none !important;
 }
 
 /* Fill the white function panel when Bridge is the active tab */
-.function-container > #bridgeSection.function-section.active.under-construction {
+.function-container > #bridgeSection.function-section.active.under-construction,
+.function-container > #bridgeSection.function-section.active[data-bridge-under-construction="1"] {
   display: flex;
   flex-direction: column;
   flex: 1;
   min-height: 0;
 }
 
-#bridgeSection.function-section.active.under-construction .under-construction-overlay {
+#bridgeSection.function-section.active.under-construction .under-construction-overlay,
+#bridgeSection.function-section.active[data-bridge-under-construction="1"] .under-construction-overlay {
   flex: 1;
   width: 100%;
   box-sizing: border-box;
@@ -2260,7 +2263,8 @@ body:has(.function-focus-state) .frontend-code-link {
   gap: 12px;
 }
 
-.function-section.under-construction .under-construction-overlay {
+.function-section.under-construction .under-construction-overlay,
+#bridgeSection[data-bridge-under-construction="1"] .under-construction-overlay {
   display: flex;
 }
 


### PR DESCRIPTION
inline rule only hid .bridge-real-content using [data-bridge-under-construction="1"]. So whenever the under-construction class was missing but the data attribute stayed (or you opened Bridge before App ran and reapplied the class):
Real bridge: hidden (good)
Overlay: still display: none (bad) → empty panel