### PR TITLE
final harden

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net https://cdn.ethers.io https://cdn.tailwindcss.com 'sha256-tPSqgOKRnJ/WEHfggnPInj/c+HOKaO+h49SR8r7YF1s=' 'sha256-SQqHoLh6BkeSdXNPEVzfkPKf+vM0fl4VaDjViheLkuY=' 'sha256-2htPfnJDN8rJzOaosKYVFFpD1K2kwsjZJL/Rh8nukeQ=' 'sha256-4nqzWaR+MoUtjlfZZVdqZSTEUjLVwV5QuxTKhUmvniU='; connect-src 'self' https://mainnet.tellorlayer.com https://node-palmito.tellorlayer.com https://mainnet.infura.io https://sepolia.infura.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; upgrade-insecure-requests"
-    />
     <title>Tellor Hub</title>
     <link rel="stylesheet" href="main.css" />
     <link rel="stylesheet" href="space-station.css?v=25" />

--- a/package.json
+++ b/package.json
@@ -2,18 +2,20 @@
   "name": "tellor-layer-bridge",
   "version": "1.0.0",
   "description": "Tellor Layer Bridge with Keplr support",
-  "main": "frontend/app.js",
+  "main": "server.js",
   "dependencies": {
     "@cosmjs/proto-signing": "^0.31.0",
     "@cosmjs/stargate": "^0.31.0",
     "ethers": "^5.7.2",
+    "express": "^5.2.1",
+    "helmet": "^8.1.0",
     "http-server": "^14.1.1",
     "protobufjs": "^7.5.1",
     "web3": "^1.7.4"
   },
   "scripts": {
-    "start": "http-server frontend -p $PORT --cors",
-    "dev": "http-server frontend -p 8000 --cors -o",
+    "start": "node server.js",
+    "dev": "PORT=8000 node server.js",
     "compile-proto": "pbjs -t static-module -w commonjs -o frontend/proto/layer_proto.js frontend/proto/bridge/tx.proto && pbts -o frontend/proto/layer_proto.d.ts frontend/proto/layer_proto.js"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const helmet = require('helmet');
+const path = require('path');
+
+const app = express();
+const port = Number(process.env.PORT || 8000);
+const frontendDir = path.join(__dirname, 'frontend');
+
+app.disable('x-powered-by');
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: false,
+      directives: {
+        defaultSrc: ["'self'"],
+        baseUri: ["'self'"],
+        objectSrc: ["'none'"],
+        frameAncestors: ["'none'"],
+        formAction: ["'self'"],
+        scriptSrc: [
+          "'self'",
+          "'unsafe-eval'",
+          'https://cdn.jsdelivr.net',
+          'https://cdn.ethers.io',
+          'https://cdn.tailwindcss.com',
+          "'sha256-tPSqgOKRnJ/WEHfggnPInj/c+HOKaO+h49SR8r7YF1s='",
+          "'sha256-SQqHoLh6BkeSdXNPEVzfkPKf+vM0fl4VaDjViheLkuY='",
+          "'sha256-2htPfnJDN8rJzOaosKYVFFpD1K2kwsjZJL/Rh8nukeQ='",
+          "'sha256-4nqzWaR+MoUtjlfZZVdqZSTEUjLVwV5QuxTKhUmvniU='"
+        ],
+        connectSrc: [
+          "'self'",
+          'https://mainnet.tellorlayer.com',
+          'https://node-palmito.tellorlayer.com',
+          'https://mainnet.infura.io',
+          'https://sepolia.infura.io'
+        ],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", 'data:', 'https:'],
+        fontSrc: ["'self'", 'data:', 'https:'],
+        upgradeInsecureRequests: []
+      }
+    },
+    crossOriginEmbedderPolicy: false
+  })
+);
+
+app.use(express.static(frontendDir));
+
+app.get('/health', (_req, res) => {
+  res.status(200).json({ ok: true });
+});
+
+app.use((_req, res) => {
+  res.sendFile(path.join(frontendDir, 'index.html'));
+});
+
+app.listen(port, () => {
+  console.log(`Tellor Hub server listening on port ${port}`);
+});


### PR DESCRIPTION
-Migrates frontend serving to an Express runtime and standardizes security headers at the HTTP layer.
-CSP enforcement is moved from HTML meta tags to server-managed response headers for cleaner production behavior.
-The server entrypoint is unified across local and Heroku via updated npm start/dev scripts.
-A lightweight /health endpoint is included for deploy verification and uptime checks.
-No product-facing feature changes are intended; this is an infrastructure/security hardening update.
-Core wallet connect/reconnect and bridge interaction paths were re-validated after the migration.