### PR TITLE
fix claim tip OOG issue

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -8,6 +8,17 @@ const LAYER_TESTNET_CHAIN_ID = 'layertest-5';
 const LAYER_TESTNET_LCD = 'https://node-palmito.tellorlayer.com';
 const LAYER_TESTNET_RPC = 'https://node-palmito.tellorlayer.com/rpc';
 
+/** Hostnames allowed for LCD gas simulate (HTTPS only). Expand for self-hosted dev. */
+const COSMOS_LCD_SIMULATE_TRUSTED_HOSTS = new Set([
+  'mainnet.tellorlayer.com',
+  'node-palmito.tellorlayer.com',
+  'localhost',
+  '127.0.0.1'
+]);
+
+/** Upper bound on gas_wanted after simulate×multiplier (many MsgWithdrawDelegatorReward in one tx). */
+const COSMOS_SIMULATE_GAS_WANTED_MAX = 12_000_000;
+
 const SEPOLIA_TOKEN_BRIDGE_ADDRESS = '0x55355157703A44f7516FBB831333317E98944e32';
 const ETHEREUM_MAINNET_TOKEN_BRIDGE_ADDRESS = '0x6ec401744008f4B018Ed9A36f76e6629799Ee50E';
 const SEPOLIA_V2_STARTING_WITHDRAW_ID = 0;
@@ -1656,6 +1667,31 @@ const App = {
       return 'https://mainnet.tellorlayer.com';
     }
     return LAYER_TESTNET_LCD;
+  },
+
+  /**
+   * Whether to call LCD /cosmos/tx/v1beta1/simulate for gas (HTTPS + known host only).
+   * Unknown hosts fall back to static gas/fee so a swapped REST URL cannot drive absurd gas_wanted.
+   */
+  cosmosRestEndpointAllowsSimulate: function(url) {
+    if (!url || typeof url !== 'string') {
+      return false;
+    }
+    if (!url.startsWith('https://')) {
+      console.warn('[Cosmos] simulate skipped: REST base must use HTTPS.', url);
+      return false;
+    }
+    try {
+      const host = new URL(url).hostname;
+      if (!COSMOS_LCD_SIMULATE_TRUSTED_HOSTS.has(host)) {
+        console.warn('[Cosmos] simulate skipped: LCD host not in trusted list.', host);
+        return false;
+      }
+    } catch (e) {
+      console.warn('[Cosmos] simulate skipped: invalid REST URL.', e);
+      return false;
+    }
+    return true;
   },
 
   // Get the appropriate Cosmos RPC endpoint based on current Cosmos network
@@ -3412,18 +3448,18 @@ const App = {
             const w = App.withdrawalAttestationDelayLabel().long;
             App.showSuccessPopup(`Withdrawal successful! You will need to wait ${w} before you can claim your tokens on Ethereum.`, txHash, 'cosmos');
         } else {
-            throw new Error(result?.rawLog || result?.raw_log || "Withdrawal failed");
+            throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Withdrawal failed'));
         }
         
         await App.updateKeplrBalance();
         return result;
         } else {
-            throw new Error(result?.rawLog || result?.raw_log || "Withdrawal failed");
+            throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Withdrawal failed'));
         }
     } catch (error) {
         // console.error(...);
         App.hidePendingPopup();
-        App.showErrorPopup(error.message || "Error withdrawing tokens. Please try again.");
+        App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Error withdrawing tokens. Please try again.'));
         throw error;
     }
   },
@@ -6707,6 +6743,7 @@ const App = {
             <select id="selectorClaimModalValidator" class="input-address">
               <option value="">Select validator destination...</option>
             </select>
+                        <div style="font-size:11px;color:#7a9e9e;line-height:1.35;">If you pick a validator you are not already delegated to, this claim creates a new delegation there (same as adding stake to that validator).</div>
           </div>
         `;
         const select = container.querySelector('#selectorClaimModalValidator');
@@ -6749,6 +6786,34 @@ const App = {
     return { offlineSigner, signerAddress };
   },
 
+  /**
+   * Turn Cosmos tx raw_log or an Error into a short user-facing popup string.
+   * Detects out-of-gas (SDK codespace) so users see guidance instead of only chain jargon.
+   */
+  cosmosTxLogOrErrorToUserMessage: function(source, fallback = 'Transaction failed.') {
+    let raw = '';
+    if (source && typeof source === 'object') {
+      if (typeof source.message === 'string') {
+        raw = source.message;
+      } else if (typeof source.raw_log === 'string') {
+        raw = source.raw_log;
+      } else if (typeof source.rawLog === 'string') {
+        raw = source.rawLog;
+      }
+    } else if (typeof source === 'string') {
+      raw = source;
+    }
+    raw = String(raw || '').trim();
+    const lower = raw.toLowerCase();
+    if (lower.includes('out of gas')) {
+      return 'This transaction ran out of gas before it could finish. Please try again in a moment. If you were claiming rewards from many validators in one step, try claiming fewer validators per transaction. If this keeps happening, contact Tellor and include any message from your wallet or block explorer.';
+    }
+    if (lower.includes('insufficient fee') || lower.includes('insufficient fees')) {
+      return 'The attached fee was too low for the network’s current minimum. Try again; if it persists, your wallet or the public node may be out of date—contact Tellor.';
+    }
+    return raw || fallback;
+  },
+
   broadcastCosmosMessages: async function(messages, memo = '') {
     if (!Array.isArray(messages) || messages.length === 0) {
       throw new Error('No messages to broadcast.');
@@ -6758,8 +6823,34 @@ const App = {
       App.getCosmosRpcEndpoint(),
       offlineSigner
     );
-    const gasAmount = Math.max(200000, 120000 * messages.length);
-    const feeAmount = Math.max(15000, 8000 * messages.length);
+    const GAS_MULT = 1.4;
+    const GAS_PRICE_LOYA = 0.025;
+    const fallbackGas = Math.max(350000, 120000 * messages.length);
+    const fallbackFee = Math.max(20000, 8000 * messages.length);
+    const minGasFloor = 80000 * messages.length;
+    const restBase = App.getCosmosApiEndpoint();
+    const simulateAllowed =
+      typeof client.simulateDirect === 'function' &&
+      App.cosmosRestEndpointAllowsSimulate(restBase);
+    let gasAmount;
+    let feeAmount;
+    if (simulateAllowed) {
+      try {
+        const simUsed = await client.simulateDirect(signerAddress, messages, memo);
+        gasAmount = Math.max(Math.ceil(simUsed * GAS_MULT), minGasFloor);
+        gasAmount = Math.min(gasAmount, COSMOS_SIMULATE_GAS_WANTED_MAX);
+        gasAmount = Math.max(gasAmount, minGasFloor);
+        feeAmount = Math.max(Math.ceil(gasAmount * GAS_PRICE_LOYA), 5000 * messages.length);
+      } catch (err) {
+        console.warn('[broadcastCosmosMessages] gas simulate failed (best-effort), using static cap:', err);
+        gasAmount = fallbackGas;
+        feeAmount = fallbackFee;
+      }
+    } else {
+      console.warn('[broadcastCosmosMessages] gas simulate skipped; using static cap.');
+      gasAmount = fallbackGas;
+      feeAmount = fallbackFee;
+    }
     return client.signAndBroadcastDirect(
       signerAddress,
       messages,
@@ -6852,14 +6943,14 @@ const App = {
       const result = await App.broadcastCosmosMessages(messages, 'Claim All Delegator Rewards');
       App.hidePendingPopup();
       if (!result || result.code !== 0) {
-        throw new Error(result?.rawLog || 'Delegator reward claim failed');
+        throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Delegator reward claim failed'));
       }
       App.showSuccessPopup('Delegator rewards claimed successfully!', result?.txhash || null, 'cosmos');
       await App.refreshCurrentStatus();
     } catch (error) {
       console.error('Failed to claim all delegator rewards:', error);
       App.hidePendingPopup();
-      App.showErrorPopup(error.message || 'Failed to claim delegator rewards');
+      App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Failed to claim delegator rewards'));
     }
   },
 
@@ -6885,14 +6976,14 @@ const App = {
       ], 'Claim Selected Delegator Reward');
       App.hidePendingPopup();
       if (!result || result.code !== 0) {
-        throw new Error(result?.rawLog || 'Selected reward claim failed');
+        throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Selected reward claim failed'));
       }
       App.showSuccessPopup('Validator reward claimed successfully!', result?.txhash || null, 'cosmos');
       await App.refreshCurrentStatus();
     } catch (error) {
       console.error('Failed to claim selected delegator reward:', error);
       App.hidePendingPopup();
-      App.showErrorPopup(error.message || 'Failed to claim selected validator reward');
+      App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Failed to claim selected validator reward'));
     }
   },
 
@@ -6922,14 +7013,14 @@ const App = {
       ], 'Claim Selector Tips');
       App.hidePendingPopup();
       if (!result || result.code !== 0) {
-        throw new Error(result?.rawLog || 'Selector tip claim failed');
+        throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Selector tip claim failed'));
       }
       App.showSuccessPopup('Selector tips claimed successfully!', result?.txhash || null, 'cosmos');
       await App.refreshCurrentStatus();
     } catch (error) {
       console.error('Failed to claim selector tips:', error);
       App.hidePendingPopup();
-      App.showErrorPopup(error.message || 'Failed to claim selector tips');
+      App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Failed to claim selector tips'));
     }
   },
 
@@ -7180,11 +7271,15 @@ const App = {
       const topValidatorAddress = topDelegation.validatorAddress;
       const topValidatorMoniker = validatorMonikers[topValidatorAddress] || 'Validator';
       const topValidatorAmountTrb = topDelegation.amountValue / 1000000;
+      const topDelegationTooltip = `${topValidatorMoniker}\n${topValidatorAddress}`
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;');
 
       statusElement.innerHTML = `
         <div class="delegation-summary-layout">
           <div class="delegation-summary-row delegation-summary-row-middle">
-            <span class="delegation-top-display">Top Delegation: ${topValidatorMoniker} (${topValidatorAmountTrb.toFixed(6)} TRB)</span>
+            <span class="delegation-top-display" title="${topDelegationTooltip}">Top Delegation: ${topValidatorMoniker} (${topValidatorAmountTrb.toFixed(6)} TRB)</span>
             <button type="button" class="delegation-remaining-toggle" onclick="App.toggleDelegationsDropdown();">
               Remaining Delegations
               <span class="dropdown-arrow" id="delegationsDropdownArrow">▼</span>
@@ -8252,12 +8347,12 @@ const App = {
                     }
                 }, 2000);
             } else {
-                throw new Error(result.rawLog || 'Transaction failed');
+                throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Transaction failed'));
             }
         } catch (error) {
             console.error('Failed to claim dispute rewards:', error);
             App.hidePendingPopup();
-            App.showErrorPopup(error.message || 'Failed to claim dispute rewards');
+            App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Failed to claim dispute rewards'));
         }
     },
 
@@ -8341,12 +8436,12 @@ const App = {
                     }
                 }, 2000);
             } else {
-                throw new Error(result.rawLog || 'Transaction failed');
+                throw new Error(App.cosmosTxLogOrErrorToUserMessage(result, 'Transaction failed'));
             }
         } catch (error) {
             console.error('Failed to withdraw fee refund:', error);
             App.hidePendingPopup();
-            App.showErrorPopup(error.message || 'Failed to withdraw fee refund');
+            App.showErrorPopup(App.cosmosTxLogOrErrorToUserMessage(error, 'Failed to withdraw fee refund'));
         }
     },
 

--- a/frontend/extensions/cosmjs/stargate.js
+++ b/frontend/extensions/cosmjs/stargate.js
@@ -125,122 +125,94 @@
             }
         }
 
-        // Unified direct signing method for all message types
-        async signAndBroadcastDirect(signerAddress, messages, fee, memo = "") {
-            try {
-                // Get account info
-                const accountInfo = await this.getAccount(signerAddress);
-
-                if (!accountInfo) {
-                    throw new Error('Account not found');
-                }
-
-                // Get the appropriate signer for direct signing
-                let offlineSigner;
-                if (window.cosmosWalletAdapter && window.cosmosWalletAdapter.isConnected()) {
-                    // Use wallet adapter if available
-                    offlineSigner = window.cosmosWalletAdapter.getOfflineSigner();
-                } else if (window.getOfflineSignerAuto) {
-                    // Fallback to legacy methods
-                    const chainId = window.App && window.App.cosmosChainId ? window.App.cosmosChainId : 'tellor-1';
-                    offlineSigner = await window.getOfflineSignerAuto(chainId);
-                } else if (window.getOfflineSignerDirect) {
-                    const chainId = window.App && window.App.cosmosChainId ? window.App.cosmosChainId : 'tellor-1';
-                    offlineSigner = window.getOfflineSignerDirect(chainId);
-                } else if (window.getOfflineSigner) {
-                    // Use the current chain ID from the app
+        async _getCosmosOfflineSigner() {
+            let offlineSigner;
+            if (window.cosmosWalletAdapter && window.cosmosWalletAdapter.isConnected()) {
+                offlineSigner = window.cosmosWalletAdapter.getOfflineSigner();
+            } else if (window.getOfflineSignerAuto) {
+                const chainId = window.App && window.App.cosmosChainId ? window.App.cosmosChainId : 'tellor-1';
+                offlineSigner = await window.getOfflineSignerAuto(chainId);
+            } else if (window.getOfflineSignerDirect) {
+                const chainId = window.App && window.App.cosmosChainId ? window.App.cosmosChainId : 'tellor-1';
+                offlineSigner = window.getOfflineSignerDirect(chainId);
+            } else if (window.getOfflineSigner) {
                 const chainId = window.App && window.App.cosmosChainId ? window.App.cosmosChainId : 'tellor-1';
                 offlineSigner = window.getOfflineSigner(chainId);
-                } else {
-                    throw new Error('No offline signer available');
-                }
+            } else {
+                throw new Error('No offline signer available');
+            }
+            return offlineSigner;
+        }
 
-                // Create protobuf types
-                const root = new protobuf.Root();
-                
-                // Define Coin type
-                const Coin = new protobuf.Type("Coin")
-                    .add(new protobuf.Field("denom", 1, "string"))
-                    .add(new protobuf.Field("amount", 2, "string"));
-                
-                // Define Any type
-                const Any = new protobuf.Type("Any")
-                    .add(new protobuf.Field("typeUrl", 1, "string"))
-                    .add(new protobuf.Field("value", 2, "bytes"));
-                
-                // Define PubKey type for secp256k1
-                const PubKey = new protobuf.Type("PubKey")
-                    .add(new protobuf.Field("key", 1, "bytes"));
-                
-                // Define TxBody type
-                const TxBody = new protobuf.Type("TxBody")
-                    .add(new protobuf.Field("messages", 1, "Any", "repeated"))
-                    .add(new protobuf.Field("memo", 2, "string"))
-                    .add(new protobuf.Field("timeoutHeight", 3, "uint64"))
-                    .add(new protobuf.Field("extensionOptions", 1023, "Any", "repeated"))
-                    .add(new protobuf.Field("nonCriticalExtensionOptions", 2047, "Any", "repeated"));
-                
-                // Define SignMode enum
-                const SignMode = new protobuf.Enum("SignMode")
-                    .add("SIGN_MODE_UNSPECIFIED", 0)
-                    .add("SIGN_MODE_DIRECT", 1)
-                    .add("SIGN_MODE_TEXTUAL", 2)
-                    .add("SIGN_MODE_LEGACY_AMINO_JSON", 127);
-                
-                // Define Single type
-                const Single = new protobuf.Type("Single")
-                    .add(new protobuf.Field("mode", 1, "SignMode"));
-                
-                // Define ModeInfo type
-                const ModeInfo = new protobuf.Type("ModeInfo")
-                    .add(new protobuf.Field("single", 1, "Single"));
-                
-                // Define SignerInfo type
-                const SignerInfo = new protobuf.Type("SignerInfo")
-                    .add(new protobuf.Field("publicKey", 1, "Any"))
-                    .add(new protobuf.Field("modeInfo", 2, "ModeInfo"))
-                    .add(new protobuf.Field("sequence", 3, "uint64"));
-                
-                // Define Fee type
-                const Fee = new protobuf.Type("Fee")
-                    .add(new protobuf.Field("amount", 1, "Coin", "repeated"))
-                    .add(new protobuf.Field("gasLimit", 2, "uint64"))
-                    .add(new protobuf.Field("payer", 3, "string"))
-                    .add(new protobuf.Field("granter", 4, "string"));
-                
-                // Define AuthInfo type
-                const AuthInfo = new protobuf.Type("AuthInfo")
-                    .add(new protobuf.Field("signerInfos", 1, "SignerInfo", "repeated"))
-                    .add(new protobuf.Field("fee", 2, "Fee"));
-                
-                // Define Tx type
-                const Tx = new protobuf.Type("Tx")
-                    .add(new protobuf.Field("body", 1, "TxBody"))
-                    .add(new protobuf.Field("authInfo", 2, "AuthInfo"))
-                    .add(new protobuf.Field("signatures", 3, "bytes", "repeated"));
+        _createDirectTxProtobufEnv() {
+            const root = new protobuf.Root();
+            const Coin = new protobuf.Type("Coin")
+                .add(new protobuf.Field("denom", 1, "string"))
+                .add(new protobuf.Field("amount", 2, "string"));
+            const Any = new protobuf.Type("Any")
+                .add(new protobuf.Field("typeUrl", 1, "string"))
+                .add(new protobuf.Field("value", 2, "bytes"));
+            const PubKey = new protobuf.Type("PubKey")
+                .add(new protobuf.Field("key", 1, "bytes"));
+            const TxBody = new protobuf.Type("TxBody")
+                .add(new protobuf.Field("messages", 1, "Any", "repeated"))
+                .add(new protobuf.Field("memo", 2, "string"))
+                .add(new protobuf.Field("timeoutHeight", 3, "uint64"))
+                .add(new protobuf.Field("extensionOptions", 1023, "Any", "repeated"))
+                .add(new protobuf.Field("nonCriticalExtensionOptions", 2047, "Any", "repeated"));
+            const SignMode = new protobuf.Enum("SignMode")
+                .add("SIGN_MODE_UNSPECIFIED", 0)
+                .add("SIGN_MODE_DIRECT", 1)
+                .add("SIGN_MODE_TEXTUAL", 2)
+                .add("SIGN_MODE_LEGACY_AMINO_JSON", 127);
+            const Single = new protobuf.Type("Single")
+                .add(new protobuf.Field("mode", 1, "SignMode"));
+            const ModeInfo = new protobuf.Type("ModeInfo")
+                .add(new protobuf.Field("single", 1, "Single"));
+            const SignerInfo = new protobuf.Type("SignerInfo")
+                .add(new protobuf.Field("publicKey", 1, "Any"))
+                .add(new protobuf.Field("modeInfo", 2, "ModeInfo"))
+                .add(new protobuf.Field("sequence", 3, "uint64"));
+            const Fee = new protobuf.Type("Fee")
+                .add(new protobuf.Field("amount", 1, "Coin", "repeated"))
+                .add(new protobuf.Field("gasLimit", 2, "uint64"))
+                .add(new protobuf.Field("payer", 3, "string"))
+                .add(new protobuf.Field("granter", 4, "string"));
+            const AuthInfo = new protobuf.Type("AuthInfo")
+                .add(new protobuf.Field("signerInfos", 1, "SignerInfo", "repeated"))
+                .add(new protobuf.Field("fee", 2, "Fee"));
+            const Tx = new protobuf.Type("Tx")
+                .add(new protobuf.Field("body", 1, "TxBody"))
+                .add(new protobuf.Field("authInfo", 2, "AuthInfo"))
+                .add(new protobuf.Field("signatures", 3, "bytes", "repeated"));
+            root.add(Coin);
+            root.add(Any);
+            root.add(PubKey);
+            root.add(TxBody);
+            root.add(SignMode);
+            root.add(Single);
+            root.add(ModeInfo);
+            root.add(SignerInfo);
+            root.add(Fee);
+            root.add(AuthInfo);
+            root.add(Tx);
+            return {
+                root,
+                TxType: root.lookupType("Tx"),
+                AnyType: root.lookupType("Any"),
+                TxBodyType: root.lookupType("TxBody"),
+                AuthInfoType: root.lookupType("AuthInfo"),
+                PubKeyType: root.lookupType("PubKey")
+            };
+        }
 
-                // Add types to root
-                root.add(Coin);
-                root.add(Any);
-                root.add(PubKey);
-                root.add(TxBody);
-                root.add(SignMode);
-                root.add(Single);
-                root.add(ModeInfo);
-                root.add(SignerInfo);
-                root.add(Fee);
-                root.add(AuthInfo);
-                root.add(Tx);
-
-                // Get the types
-                const TxType = root.lookupType("Tx");
-                const AnyType = root.lookupType("Any");
-                const TxBodyType = root.lookupType("TxBody");
-                const AuthInfoType = root.lookupType("AuthInfo");
-                const PubKeyType = root.lookupType("PubKey");
-
-                // Encode messages based on their type
+        _encodeDirectMessagesForSigning(messages, root) {
                 const encodedMessages = [];
+                const dbgEncode = (...args) => {
+                    if (window.App && typeof window.App.debugLog === 'function') {
+                        window.App.debugLog(...args);
+                    }
+                };
                 for (const message of messages) {
                     let encodedMessage;
                     
@@ -267,7 +239,7 @@
                             }
                         };
                         
-                        console.log('Encoding MsgWithdrawTokens:', msgValue);
+                        dbgEncode('Encoding MsgWithdrawTokens:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.bridge.MsgRequestAttestations') {
                         // Encode attestation request message using the same approach as the original Amino method
@@ -359,7 +331,7 @@
                             payFromBond: message.value.payFromBond
                         };
                         
-                        console.log('Encoding MsgProposeDispute:', msgValue);
+                        dbgEncode('Encoding MsgProposeDispute:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.dispute.MsgVote') {
                         // Encode dispute vote message
@@ -377,8 +349,7 @@
                             vote: message.value.vote
                         };
                         
-                        console.log('Encoding MsgVote:', msgValue);
-                        console.log('Vote field type:', typeof msgValue.vote, 'Value:', msgValue.vote);
+                        dbgEncode('Encoding MsgVote:', msgValue, 'vote field type:', typeof msgValue.vote, msgValue.vote);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.dispute.MsgAddFeeToDispute') {
                         // Encode dispute add fee message
@@ -398,7 +369,7 @@
                             payFromBond: message.value.payFromBond
                         };
                         
-                        console.log('Encoding MsgAddFeeToDispute:', msgValue);
+                        dbgEncode('Encoding MsgAddFeeToDispute:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.dispute.MsgClaimDisputeRewards') {
                         // Encode claim dispute rewards message
@@ -414,7 +385,7 @@
                             disputeId: message.value.disputeId
                         };
                         
-                        console.log('Encoding MsgClaimDisputeRewards:', msgValue);
+                        dbgEncode('Encoding MsgClaimDisputeRewards:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.dispute.MsgWithdrawFeeRefund') {
                         // Encode withdraw fee refund message
@@ -430,7 +401,7 @@
                             disputeId: message.value.disputeId
                         };
                         
-                        console.log('Encoding MsgWithdrawFeeRefund:', msgValue);
+                        dbgEncode('Encoding MsgWithdrawFeeRefund:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.reporter.MsgSelectReporter') {
                         // Encode reporter selection message
@@ -446,7 +417,7 @@
                             reporterAddress: message.value.reporterAddress
                         };
                         
-                        console.log('Encoding MsgSelectReporter:', msgValue);
+                        dbgEncode('Encoding MsgSelectReporter:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.reporter.MsgSwitchReporter') {
                         // Encode reporter switch message
@@ -462,7 +433,7 @@
                             reporterAddress: message.value.reporterAddress
                         };
 
-                        console.log('Encoding MsgSwitchReporter:', msgValue);
+                        dbgEncode('Encoding MsgSwitchReporter:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else if (message.typeUrl === '/layer.reporter.MsgWithdrawTip') {
                         // Encode selector tip withdrawal message
@@ -478,7 +449,7 @@
                             validatorAddress: message.value.validatorAddress
                         };
 
-                        console.log('Encoding MsgWithdrawTip:', msgValue);
+                        dbgEncode('Encoding MsgWithdrawTip:', msgValue);
                         encodedMessage = MsgType.encode(MsgType.create(msgValue)).finish();
                     } else {
                         throw new Error(`Unsupported message type: ${message.typeUrl}`);
@@ -491,6 +462,96 @@
                     };
                     encodedMessages.push(messageAny);
                 }
+                return encodedMessages;
+        }
+
+        /**
+         * Dry-run the same messages via LCD /cosmos/tx/v1beta1/simulate (CosmJS-style unsigned Tx).
+         * @returns {Promise<number>} gas_used from simulation
+         */
+        async simulateDirect(signerAddress, messages, memo = '') {
+            const accountInfo = await this.getAccount(signerAddress);
+            if (!accountInfo) {
+                throw new Error('Account not found');
+            }
+            const offlineSigner = await this._getCosmosOfflineSigner();
+            const accounts = await offlineSigner.getAccounts();
+            if (!accounts || accounts.length === 0) {
+                throw new Error('No accounts found in signer');
+            }
+            const env = this._createDirectTxProtobufEnv();
+            const encodedMessages = this._encodeDirectMessagesForSigning(messages, env.root);
+            const txBody = {
+                messages: encodedMessages,
+                memo: memo || '',
+                timeoutHeight: 0,
+                extensionOptions: [],
+                nonCriticalExtensionOptions: []
+            };
+            const encodedTxBody = env.TxBodyType.encode(env.TxBodyType.create(txBody)).finish();
+            const authInfoSimulate = {
+                signerInfos: [{
+                    publicKey: {
+                        typeUrl: '/cosmos.crypto.secp256k1.PubKey',
+                        value: env.PubKeyType.encode({ key: accounts[0].pubkey }).finish()
+                    },
+                    modeInfo: {
+                        single: {
+                            mode: 0
+                        }
+                    },
+                    sequence: parseInt(String(accountInfo.sequence), 10)
+                }],
+                fee: {
+                    amount: [],
+                    gasLimit: 0,
+                    payer: '',
+                    granter: ''
+                }
+            };
+            const encodedAuthInfo = env.AuthInfoType.encode(env.AuthInfoType.create(authInfoSimulate)).finish();
+            const simTx = {
+                body: env.TxBodyType.decode(encodedTxBody),
+                authInfo: env.AuthInfoType.decode(encodedAuthInfo),
+                signatures: [new Uint8Array(0)]
+            };
+            const encodedTx = env.TxType.encode(env.TxType.create(simTx)).finish();
+            const base64Tx = btoa(String.fromCharCode.apply(null, encodedTx));
+            const response = await fetch(`${this.getRestBase()}/cosmos/tx/v1beta1/simulate`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ tx_bytes: base64Tx })
+            });
+            const result = await response.json();
+            if (!response.ok) {
+                throw new Error((result && (result.message || result.error)) || `Simulate HTTP ${response.status}`);
+            }
+            const gasInfo = result.gas_info || result.gasInfo;
+            const gasUsed = gasInfo && (gasInfo.gas_used !== undefined ? gasInfo.gas_used : gasInfo.gasUsed);
+            if (gasUsed === undefined || gasUsed === null) {
+                throw new Error((result.message || JSON.stringify(result)).slice(0, 500) || 'Simulate returned no gas_info');
+            }
+            const n = parseInt(String(gasUsed), 10);
+            if (!Number.isFinite(n) || n <= 0) {
+                throw new Error(`Invalid simulated gas: ${gasUsed}`);
+            }
+            return n;
+        }
+
+        // Unified direct signing method for all message types
+        async signAndBroadcastDirect(signerAddress, messages, fee, memo = "") {
+            try {
+                const accountInfo = await this.getAccount(signerAddress);
+                if (!accountInfo) {
+                    throw new Error('Account not found');
+                }
+                const offlineSigner = await this._getCosmosOfflineSigner();
+                const env = this._createDirectTxProtobufEnv();
+                const encodedMessages = this._encodeDirectMessagesForSigning(messages, env.root);
+                const TxBodyType = env.TxBodyType;
+                const TxType = env.TxType;
+                const AuthInfoType = env.AuthInfoType;
+                const PubKeyType = env.PubKeyType;
 
                 // Create the TxBody
                 const txBody = {

--- a/frontend/main.css
+++ b/frontend/main.css
@@ -3415,6 +3415,7 @@ header {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    cursor: help;
 }
 
 #delegateSection .delegation-remaining-toggle {

--- a/frontend/tests/unit-tests.js
+++ b/frontend/tests/unit-tests.js
@@ -267,6 +267,14 @@ export class UnitTests extends TestSuite {
         run: () => this.testSelectorTipsClaimSuccessFlow()
       },
       {
+        name: 'Cosmos LCD simulate gate (HTTPS + trusted host)',
+        run: () => this.testCosmosRestEndpointAllowsSimulate()
+      },
+      {
+        name: 'Cosmos tx error messages (out of gas user copy)',
+        run: () => this.testCosmosTxLogOrErrorToUserMessage()
+      },
+      {
         name: 'Claim modals show moniker with validator address',
         run: () => this.testClaimModalValidatorOptionLabels()
       },
@@ -1335,6 +1343,36 @@ export class UnitTests extends TestSuite {
       window.fetch = prevFetch;
       window.App.cosmosChainId = prevChain;
     }
+  }
+
+  testCosmosRestEndpointAllowsSimulate() {
+    const f = window.App.cosmosRestEndpointAllowsSimulate;
+    if (typeof f !== 'function') {
+      throw new Error('App.cosmosRestEndpointAllowsSimulate missing');
+    }
+    this.assertTrue(f('https://mainnet.tellorlayer.com'), 'Mainnet LCD host should allow simulate');
+    this.assertTrue(f('https://node-palmito.tellorlayer.com'), 'Palmito LCD host should allow simulate');
+    this.assertTrue(f('https://localhost:1317'), 'localhost HTTPS should allow simulate');
+    this.assertTrue(f('https://127.0.0.1:1317'), '127.0.0.1 HTTPS should allow simulate');
+    this.assertFalse(f('http://mainnet.tellorlayer.com'), 'HTTP should not allow simulate');
+    this.assertFalse(f('https://untrusted-lcd.example.com'), 'Unknown host should not allow simulate');
+    this.assertFalse(f(''), 'Empty URL should not allow simulate');
+    this.assertFalse(f('not-a-valid-url'), 'Invalid URL should not allow simulate');
+  }
+
+  testCosmosTxLogOrErrorToUserMessage() {
+    const f = window.App.cosmosTxLogOrErrorToUserMessage;
+    if (typeof f !== 'function') {
+      throw new Error('App.cosmosTxLogOrErrorToUserMessage missing');
+    }
+    const oogLog =
+      'out of gas in location: ReadFlat; gasWanted: 200000, gasUsed: 200153: out of gas';
+    const oogMsg = f(oogLog, 'fallback');
+    this.assertTrue(oogMsg.includes('ran out of gas'), 'OOG raw_log should map to user guidance');
+    this.assertFalse(oogMsg.includes('ReadFlat'), 'User message should not echo low-level SDK location');
+    this.assertEqual(f({ raw_log: 'something else happened' }, 'fb'), 'something else happened');
+    this.assertEqual(f({ message: 'insufficient fees' }, 'fb'), f('insufficient fees', 'fb'));
+    this.assertTrue(f('insufficient fee', 'fb').toLowerCase().includes('fee was too low'));
   }
 
   async testSelectorTipsClaimSuccessFlow() {


### PR DESCRIPTION
-Estimate gas for broadcastCosmosMessages via LCD /cosmos/tx/v1beta1/simulate (CosmJS-style unsigned tx), apply a 1.4× headroom, and set fees from the existing 0.025 loya/gas assumption; fall back to static caps if simulate is unavailable or blocked.

-Add hover-over tooltip for top delegated vaidaotor to view full moniker and address

-Only run simulate when the REST base is HTTPS and the host is on a small allowlist; cap gas_wanted after simulation to limit griefing from a bad LCD response.

-Add error popup messaging for OOG errors

-Refactor the vendored SigningStargateClient to share message encoding between simulate and sign; move encode-step logs behind App.debugLog so normal users do not see duplicate Encoding Msg* noise.

-Map common chain failures (out of gas, insufficient fee) to clearer error popups for selector tips, delegator rewards, bridge withdraw, and dispute reward/refund flows.

-Add unit tests for the LCD simulate gate and for the user-facing Cosmos error message helper.